### PR TITLE
Überprüfung der YouTube-Kanal-ID hinzugefügt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+*.db

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Dieser Bot überwacht den YouTube-Kanal auf Live-Übertragungen des Bundestags. Wenn eine Live-Übertragung erkannt wird, sendet der Bot eine Benachrichtigung in den angegebenen Discord-Channel mit Details zum Livestream.
 
-Der Live-Status wird alle 5 Minuten überprüft.
+Der Live-Status wird alle 30 Minuten überprüft.
 
 > Du kannst den Bot hier einladen: [Einladen](https://discord.com/api/oauth2/authorize?client_id=1210581379155370094&permissions=277025508352&scope=applications.commands+bot)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Um den Bot nutzen zu können benötigst du:
 1. Klone das Repository:
 
    ```bash
-   git clone https://github.com/Toaaa/bundestag-live-bot.git
+   git clone https://github.com/Toaaa/Bundestag-Live.git
    ```
 
 2. Installiere die Abhängigkeiten:

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "repository": "git@github.com:toaaa/bundestag-live.git",
   "dependencies": {
     "@discordjs/builders": "^1.7.0",
-    "@types/node": "^20.11.20",
     "axios": "^1.6.7",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5",
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
+    "@types/node": "^20.11.20",
     "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@discordjs/builders':
     specifier: ^1.7.0
     version: 1.7.0
-  '@types/node':
-    specifier: ^20.11.20
-    version: 20.11.20
   axios:
     specifier: ^1.6.7
     version: 1.6.7
@@ -25,6 +22,9 @@ dependencies:
     version: 5.1.7
 
 devDependencies:
+  '@types/node':
+    specifier: ^20.11.20
+    version: 20.11.20
   typescript:
     specifier: ^5.3.3
     version: 5.3.3
@@ -159,7 +159,6 @@ packages:
     resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
     dependencies:
       undici-types: 5.26.5
-    dev: false
 
   /@types/ws@8.5.9:
     resolution: {integrity: sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==}
@@ -1103,9 +1102,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0
@@ -1213,7 +1209,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: false
 
   /undici@5.27.2:
     resolution: {integrity: sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,8 +216,8 @@ const checkYouTubeLiveStatus = async () => {
 
             if (liveVideo) {
               const videoId = liveVideo.id.videoId;
-              const channelId = liveVideo.snippet.channelId;
-              if (channelId !== youtubeChannelId) return;
+              const liveChannelId = liveVideo.snippet.channelId;
+              if (liveChannelId !== youtubeChannelId) return;
 
               if (!postedVideoIds.has(videoId)) {
                 console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ if (!youtubeApiKey || !discordBotToken || !youtubeChannelId) {
 
 db.serialize(() => {
   db.run(
-    "CREATE TABLE IF NOT EXISTS guilds (id TEXT, guild_id TEXT, channel_id TEXT, PRIMARY KEY (id, guild_id))"
+    "CREATE TABLE IF NOT EXISTS guilds (guild_id TEXT, channel_id TEXT, PRIMARY KEY (guild_id))"
   );
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,7 @@ const checkYouTubeLiveStatus = async () => {
                   description: liveVideo.snippet.title,
                   url: `https://www.youtube.com/watch?v=${videoId}`,
                   color: 0xff0000,
-                  timestamp: new Date().toISOString(),
+                  timestamp: new Date().toLocaleString('de-DE', { timeZone: 'Europe/Berlin' }),
                   footer: {
                     text: `Bundestag Live Ankündigung • ${videoId}`,
                   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,8 @@ const checkYouTubeLiveStatus = async () => {
 
             if (liveVideo) {
               const videoId = liveVideo.id.videoId;
-              if (liveVideo.snippet.channelId !== youtubeChannelId) return;
+              const channelId = liveVideo.snippet.channelId;
+              if (channelId !== youtubeChannelId) return;
 
               if (!postedVideoIds.has(videoId)) {
                 console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,9 @@ client.on("ready", async () => {
     console.error(err);
   }
 
-  await checkYouTubeLiveStatus();
-  setInterval(async () => await checkYouTubeLiveStatus(), 5 * 60 * 1000);
+  setInterval(async () => {
+    await checkYouTubeLiveStatus();
+  }, 30 * 60 * 1000);
 });
 
 client.on(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import axios from "axios";
 import dotenv from "dotenv";
 import sqlite3 from "sqlite3";
 import fs from "fs";
+import { error } from "console";
 
 dotenv.config();
 
@@ -205,6 +206,7 @@ client.on("command", (command: ApplicationCommand) => {
 
 const checkYouTubeLiveStatus = async () => {
   try {
+    console.log("Überprüfe Live-Status...");
     const guilds = Array.from(client.guilds.cache.values());
 
     for (const guild of guilds) {
@@ -227,6 +229,13 @@ const checkYouTubeLiveStatus = async () => {
             const response = await axios.get(
               `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${youtubeChannelId}&eventType=live&type=video&key=${youtubeApiKey}`
             );
+
+            if (!response) {
+              console.error(
+                `Fehler bei der API-Abfrage! URL: 'https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${youtubeChannelId}&eventType=live&type=video&key=${youtubeApiKey}'`
+              );
+              return;
+            }
 
             const liveVideo = response.data.items?.[0];
 
@@ -265,6 +274,8 @@ const checkYouTubeLiveStatus = async () => {
                   await channel.send({ embeds: [embed] });
                 }
 
+                console.log(`Füge '${videoId}' zu postedVideoIds hinzu.`);
+                console.log(`postedVideoIds: ${postedVideoIds}`);
                 postedVideoIds.add(videoId);
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,7 @@ const checkYouTubeLiveStatus = async () => {
 
             if (liveVideo) {
               const videoId = liveVideo.id.videoId;
+              if (liveVideo.snippet.channelId !== youtubeChannelId) return;
 
               if (!postedVideoIds.has(videoId)) {
                 console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ const checkYouTubeLiveStatus = async () => {
             const newChannelId: string = row.channel_id!;
 
             const response = await axios.get(
-              `https://www.googleapis.com/youtube/v3/search?part=snippet&newChannelId=${youtubeChannelId}&eventType=live&type=video&key=${youtubeApiKey}`
+              `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${youtubeChannelId}&eventType=live&type=video&key=${youtubeApiKey}`
             );
 
             const liveVideo = response.data.items?.[0];


### PR DESCRIPTION
Diese Änderung erweitert die Live-Stream-Verarbeitung, indem die Überprüfung der YouTube-Kanal-ID für den Live-Stream hinzugefügt wird. Dadurch wird sichergestellt, dass nur Live-Streams des spezifischen YouTube-Kanals verarbeitet werden. Wichtig, um unerwünschte Streams zu filtern.